### PR TITLE
Feat: Add support for css entry files, fix #3

### DIFF
--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -80,6 +80,12 @@ class Manifest
      */
     public function getEntrypoint(string $entrypoint, bool $hash = true): array
     {
+        // if entrypoint is a css file return an empty array
+        if (substr($entrypoint, -4) === ".css")
+        {
+            return [];
+        }
+
         return isset($this->manifest[$entrypoint]) ? [
             "hash" => $hash ? $this->getFileHash($this->manifest[$entrypoint]["file"]) : null,
             "url"  => $this->getPath($this->manifest[$entrypoint]["file"])

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -121,7 +121,22 @@ class Manifest
     public function getStyles(string $entrypoint, bool $hash = true): array
     {
         // TODO: Refactor for PHP 8.x
-        if (!isset($this->manifest[$entrypoint]) || !isset($this->manifest[$entrypoint]["css"]) || !is_array($this->manifest[$entrypoint]["css"]))
+        if (!isset($this->manifest[$entrypoint]))
+        {
+            return [];
+        }
+
+        // If entrypoint is file, is an entry and ends with .css return it.
+        if (isset($this->manifest[$entrypoint]["file"], $this->manifest[$entrypoint]["isEntry"]) && $this->manifest[$entrypoint]["isEntry"] && substr($this->manifest[$entrypoint]["file"], -4) === ".css")
+        {
+            return [[
+                "hash" => $hash ? $this->getFileHash($this->manifest[$entrypoint]["file"]) : null,
+                "url"  => $this->getPath($this->manifest[$entrypoint]["file"])
+            ]];
+        }
+
+
+        if (!isset($this->manifest[$entrypoint]["css"]) || !is_array($this->manifest[$entrypoint]["css"]))
         {
             return [];
         }

--- a/tests/_data/manifest-css-entry.json
+++ b/tests/_data/manifest-css-entry.json
@@ -1,7 +1,7 @@
 {
-  "src/main.css": {
-    "file": "assets/main-deadbeef.css",
+  "index.css": {
+    "file": "assets/index.deadbeef.css",
     "isEntry": true,
-    "src": "src/main.css"
+    "src": "index.css"
   }
 }

--- a/tests/_data/manifest-css-entry.json
+++ b/tests/_data/manifest-css-entry.json
@@ -1,0 +1,7 @@
+{
+  "src/main.css": {
+    "file": "assets/main-deadbeef.css",
+    "isEntry": true,
+    "src": "src/main.css"
+  }
+}

--- a/tests/unit/ViteManifestCssEntryTest.php
+++ b/tests/unit/ViteManifestCssEntryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Idleberg\ViteManifest\Manifest;
+
+class ViteManifestCssEntryTest extends \Codeception\Test\Unit
+{
+    /**
+     * @var \UnitTester
+     */
+    protected $tester;
+    protected $vm;
+    protected $baseUrl = __DIR__ . "/../_data/";
+    protected $manifest = __DIR__ . "/../_data/manifest-css-entry.json";
+
+    protected function _before()
+    {
+        $this->vm = new Manifest($this->manifest, $this->baseUrl);
+    }
+
+    protected function _after()
+    {
+        // The void
+    }
+
+    // tests
+    public function testGetManifest()
+    {
+        $actual = $this->vm->getManifest();
+        $expected = json_decode('{"src/main.css":{"file": "assets/main-deadbeef.css","isEntry": true,"src": "src/main.css"}}', true);
+
+        $this->assertEquals($actual, $expected);
+    }
+
+    public function testGetStyles()
+    {
+        $this->assertEquals(count($this->vm->getStyles("src/main.css")), 1);
+    }
+}

--- a/tests/unit/ViteManifestCssEntryTest.php
+++ b/tests/unit/ViteManifestCssEntryTest.php
@@ -35,4 +35,8 @@ class ViteManifestCssEntryTest extends \Codeception\Test\Unit
     {
         $this->assertEquals(count($this->vm->getStyles("index.css")), 1);
     }
+
+    public function testGetEntrypoint() {
+        $this->assertEquals(count($this->vm->getEntrypoint("index.css")), 0);
+    }
 }

--- a/tests/unit/ViteManifestCssEntryTest.php
+++ b/tests/unit/ViteManifestCssEntryTest.php
@@ -26,13 +26,13 @@ class ViteManifestCssEntryTest extends \Codeception\Test\Unit
     public function testGetManifest()
     {
         $actual = $this->vm->getManifest();
-        $expected = json_decode('{"src/main.css":{"file": "assets/main-deadbeef.css","isEntry": true,"src": "src/main.css"}}', true);
+        $expected = json_decode('{"index.css":{"file": "assets/index.deadbeef.css","isEntry": true,"src": "index.css"}}', true);
 
         $this->assertEquals($actual, $expected);
     }
 
     public function testGetStyles()
     {
-        $this->assertEquals(count($this->vm->getStyles("src/main.css")), 1);
+        $this->assertEquals(count($this->vm->getStyles("index.css")), 1);
     }
 }


### PR DESCRIPTION
Hi @idleberg ,

This feature adds support for css entry files as discussed in the related issue.

I've also tested this with _wordpress-vite-assets_ and the following is now working as expected. Previously the css file was added as a script tag.

```php
$viteAssets->inject(["src/main.js", "src/main.css"], [
  'integrity' => FALSE
]);
```