### PR TITLE
Add minimal fix for getStyles and css entry point #3

### DIFF
--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -121,7 +121,20 @@ class Manifest
     public function getStyles(string $entrypoint, bool $hash = true): array
     {
         // TODO: Refactor for PHP 8.x
-        if (!isset($this->manifest[$entrypoint]) || !isset($this->manifest[$entrypoint]["css"]) || !is_array($this->manifest[$entrypoint]["css"]))
+        if (!isset($this->manifest[$entrypoint]))
+        {
+            return [];
+        }
+
+        if (isset($this->manifest[$entrypoint]["file"]) && str_ends_with($this->manifest[$entrypoint]["file"], '.css'))
+        {
+            return [[
+                "hash" => $hash ? $this->getFileHash($this->manifest[$entrypoint]["file"]) : null,
+                "url"  => $this->getPath($this->manifest[$entrypoint]["file"])
+            ]];
+        }
+
+        if (!isset($this->manifest[$entrypoint]["css"]) || !is_array($this->manifest[$entrypoint]["css"]))
         {
             return [];
         }

--- a/tests/_data/manifest-css-entry.json
+++ b/tests/_data/manifest-css-entry.json
@@ -1,0 +1,7 @@
+{
+  "index.css": {
+    "file": "assets/index.deadbeef.css",
+    "isEntry": true,
+    "src": "index.css"
+  }
+}

--- a/tests/unit/ViteManifestCssEntryTest.php
+++ b/tests/unit/ViteManifestCssEntryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Idleberg\ViteManifest\Manifest;
+
+class ViteManifestCssEntryTest extends \Codeception\Test\Unit
+{
+    /**
+     * @var \UnitTester
+     */
+    protected $tester;
+    protected $vm;
+    protected $baseUrl = __DIR__ . "/../_data/";
+    protected $manifest = __DIR__ . "/../_data/manifest-css-entry.json";
+
+    protected function _before()
+    {
+        $this->vm = new Manifest($this->manifest, $this->baseUrl);
+    }
+
+    protected function _after()
+    {
+        // The void
+    }
+
+    // tests
+    public function testGetManifest()
+    {
+        $actual = $this->vm->getManifest();
+        $expected = json_decode('{"index.css":{"file": "assets/index.deadbeef.css","isEntry": true,"src": "index.css"}}', true);
+
+        $this->assertEquals($actual, $expected);
+    }
+
+    public function testGetStyles()
+    {
+        $this->assertEquals(count($this->vm->getStyles("index.css")), 1);
+    }
+}


### PR DESCRIPTION
Here is a more minimal fix to make the `getStyles` method return css entry points.

I can confirm that in my setup, using this fix with the other [one here](https://github.com/idleberg/php-wordpress-vite-assets/commit/a19f9aa290554d258ad4b8f77c1ca3221cc7159c) fixes the issue.